### PR TITLE
Hedgehog

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,14 +1,26 @@
 { nixpkgs ? import <nixpkgs> {}, compiler ? "default" }:
-
 let
-
   inherit (nixpkgs) pkgs;
-
   haskellPackages = if compiler == "default"
                        then pkgs.haskellPackages
                        else pkgs.haskell.packages.${compiler};
 
-  exitcode = haskellPackages.callPackage ./exitcode.nix {};
+  tasty-hedgehog-github = pkgs.callPackage (pkgs.fetchFromGitHub {
+    owner = "qfpl";
+    repo = "tasty-hedgehog";
+    rev = "5da389f5534943b430300a213c5ffb5d0e13459e";
+    sha256 = "04pmr9q70gakd327sywpxr7qp8jnl3b0y2sqxxxcj6zj2q45q38m";
+  }) {};
 
+  modifiedHaskellPackages = haskellPackages.override {
+    overrides = self: super: {
+      tasty-hedgehog =
+        if super ? tasty-hedgehog
+        then super.tasty-hedgehog
+        else tasty-hedgehog-github;
+    };
+  };
+
+  exitcode = modifiedHaskellPackages.callPackage ./exitcode.nix {};
 in
   exitcode

--- a/exitcode.cabal
+++ b/exitcode.cabal
@@ -38,7 +38,8 @@ library
   ghc-options:         -Wall
 
 test-suite             tests
-  build-depends:       base >=4.8 && <4.11
+  build-depends:       QuickCheck >=2.9.2 && <2.11
+                     , base >=4.8 && <4.11
                      , checkers >=0.4.6 && <0.5
                      , exitcode
                      , hedgehog >=0.5 && <0.6
@@ -46,6 +47,7 @@ test-suite             tests
                      , tasty >=0.11 && <0.12
                      , tasty-hunit >=0.9 && <0.10
                      , tasty-hedgehog >= 0.1 && <0.2
+                     , tasty-quickcheck >=0.8.4 && <0.10
                      , transformers >=0.4.1 && <5.5
   type:                exitcode-stdio-1.0
   main-is:             Tests.hs

--- a/exitcode.cabal
+++ b/exitcode.cabal
@@ -38,14 +38,14 @@ library
   ghc-options:         -Wall
 
 test-suite             tests
-  build-depends:       QuickCheck >=2.9.2 && <2.11
-                     , base >=4.8 && <4.11
+  build-depends:       base >=4.8 && <4.11
                      , checkers >=0.4.6 && <0.5
                      , exitcode
+                     , hedgehog >=0.5 && <0.6
                      , lens >=4.15 && <4.16
                      , tasty >=0.11 && <0.12
                      , tasty-hunit >=0.9 && <0.10
-                     , tasty-quickcheck >=0.8.4 && <0.10
+                     , tasty-hedgehog >= 0.1 && <0.2
                      , transformers >=0.4.1 && <5.5
   type:                exitcode-stdio-1.0
   main-is:             Tests.hs

--- a/exitcode.nix
+++ b/exitcode.nix
@@ -1,6 +1,6 @@
-{ mkDerivation, base, checkers, hedgehog, lens, mtl, semigroupoids
-, semigroups, stdenv, tasty, tasty-hedgehog, tasty-hunit
-, transformers
+{ mkDerivation, base, checkers, hedgehog, lens, mtl, QuickCheck
+, semigroupoids, semigroups, stdenv, tasty, tasty-hedgehog
+, tasty-hunit, tasty-quickcheck, transformers
 }:
 mkDerivation {
   pname = "exitcode";
@@ -10,8 +10,8 @@ mkDerivation {
     base lens mtl semigroupoids semigroups transformers
   ];
   testHaskellDepends = [
-    base checkers hedgehog lens tasty tasty-hedgehog tasty-hunit
-    transformers
+    base checkers hedgehog lens QuickCheck tasty tasty-hedgehog
+    tasty-hunit tasty-quickcheck transformers
   ];
   homepage = "https://github.com/qfpl/exitcode";
   description = "Monad transformer for exit codes";

--- a/exitcode.nix
+++ b/exitcode.nix
@@ -1,6 +1,6 @@
-{ mkDerivation, base, checkers, lens, mtl, QuickCheck
-, semigroupoids, semigroups, stdenv, tasty, tasty-hunit
-, tasty-quickcheck, transformers
+{ mkDerivation, base, checkers, hedgehog, lens, mtl, semigroupoids
+, semigroups, stdenv, tasty, tasty-hedgehog, tasty-hunit
+, transformers
 }:
 mkDerivation {
   pname = "exitcode";
@@ -10,7 +10,7 @@ mkDerivation {
     base lens mtl semigroupoids semigroups transformers
   ];
   testHaskellDepends = [
-    base checkers lens QuickCheck tasty tasty-hunit tasty-quickcheck
+    base checkers hedgehog lens tasty tasty-hedgehog tasty-hunit
     transformers
   ];
   homepage = "https://github.com/qfpl/exitcode";

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -4,12 +4,17 @@ import           Data.Functor.Classes      (Eq1)
 import           Data.Functor.Identity     (Identity (..), runIdentity)
 import           Data.Monoid               ((<>))
 
-import           Test.QuickCheck           (Arbitrary (..), suchThat)
+import           Hedgehog                  (forAll, property, (===))
+import qualified Hedgehog.Gen              as Gen
+import           Hedgehog.Internal.Gen     (MonadGen)
+import qualified Hedgehog.Range            as Range
+import           Test.QuickCheck           (Arbitrary)
 import           Test.QuickCheck.Checkers  (EqProp (..), Test, TestBatch, eq)
 import           Test.QuickCheck.Classes   (applicative, functor)
 import           Test.Tasty                (TestTree, defaultMain, testGroup)
+import           Test.Tasty.Hedgehog       (testProperty)
 import           Test.Tasty.HUnit          (testCase, (@?=))
-import           Test.Tasty.QuickCheck     (testProperty)
+import qualified Test.Tasty.QuickCheck     as TQC
 
 import           Control.Exitcode          (Exitcode, ExitcodeT, exitCode,
                                             exitfailure0, exitsuccess,
@@ -21,7 +26,7 @@ import           System.Exit               (ExitCode (..))
 newtype EW f a = EW { unEW :: ExitcodeT f a } deriving (Eq, Show)
 
 instance (Applicative f, Arbitrary a) => Arbitrary (EW f a) where
-  arbitrary = fmap (EW . pure) arbitrary
+  arbitrary = fmap (EW . pure) TQC.arbitrary
 
 instance Functor f => Functor (EW f) where
   fmap f = EW . fmap f . unEW
@@ -35,10 +40,10 @@ instance (Eq1 f, Eq a) => EqProp (EW f a) where
 
 type CheckMe = EW [] (Integer, Integer, Integer)
 
-newtype NonZero = NonZero Int deriving Show
-
-instance Arbitrary NonZero where
-  arbitrary = NonZero <$> suchThat arbitrary (/= 0)
+nonZero :: MonadGen m => m Int
+nonZero =
+  let allOfTheInts = Range.linear (minBound :: Int) (maxBound :: Int)
+   in Gen.filter (/= 0) (Gen.int allOfTheInts)
 
 main :: IO ()
 main = defaultMain test_Exitcode
@@ -65,12 +70,12 @@ applicativeTest =
 exitFailurePrismTest :: TestTree
 exitFailurePrismTest =
   testGroup "_ExitFailure Prism" [
-    testProperty "review non-zero input" $
-      \(NonZero n) -> review _ExitFailure n == exitfailure0 n
+    testProperty "review non-zero input" . property $
+      forAll nonZero >>= (\n -> review _ExitFailure n === exitfailure0 n)
   , testCase "review 0" $
       review _ExitFailure 0 @?= exitsuccess0
-  , testProperty "view non-zero input" $
-      \(NonZero n) -> exitfailure0 n ^? _ExitFailure == Just n
+  , testProperty "view non-zero input" . property $
+      forAll nonZero >>= (\n -> exitfailure0 n ^? _ExitFailure === Just n)
   , testCase "view 0" $
       exitfailure0 0 ^? _ExitFailure @?= Nothing
   ]
@@ -82,8 +87,8 @@ exitSuccessPrismTest =
       review _ExitSuccess () @?= exitsuccess0
   , testCase "view exitsuccess0" $
       exitsuccess0 ^? _ExitSuccess @?= Just ()
-  , testProperty "view exitfailure0 non-zero" $
-      \(NonZero n) -> exitfailure0 n ^? _ExitSuccess == Nothing
+  , testProperty "view exitfailure0 non-zero" . property $
+      forAll nonZero >>= (\n -> exitfailure0 n ^? _ExitSuccess === Nothing)
   , testCase "view exitfailure0 0" $
       exitfailure0 0 ^? _ExitSuccess @?= Just ()
   ]
@@ -91,8 +96,8 @@ exitSuccessPrismTest =
 exitfailure0Test :: TestTree
 exitfailure0Test =
   testGroup "exitfailure0" [
-    testProperty "non-zero input" $
-      \(NonZero n) -> (runIdentity . runExitcode) (exitfailure0 n) == Left n
+    testProperty "non-zero input" . property $
+      forAll nonZero >>= (\n -> (runIdentity . runExitcode) (exitfailure0 n) === Left n)
   , testCase "0" $
       (runIdentity . runExitcode) (exitfailure0 0) @?= Right ()
   ]
@@ -100,14 +105,14 @@ exitfailure0Test =
 exitCodePrismTest :: TestTree
 exitCodePrismTest =
   testGroup "exitCode Prism" [
-    testProperty "`exitfailure0 n`, where n is non-zero" $
-      \(NonZero n) -> (review exitCode (exitfailure0 n)) == Identity (ExitFailure n)
+    testProperty "`exitfailure0 n`, where n is non-zero" . property $
+      forAll nonZero >>= \n -> (review exitCode (exitfailure0 n)) === Identity (ExitFailure n)
   , testCase "review `exitfailure 0`" $
       runIdentity (review exitCode (exitfailure0 0)) @?= ExitSuccess
   , testCase "review `exitsuccess0`" $
       runIdentity (review exitCode exitsuccess0) @?= ExitSuccess
-  , testProperty "view ExitFailure n, where n is non-zero" $
-      \(NonZero n) -> Identity (ExitFailure n) ^? exitCode == Just (exitfailure0 n)
+  , testProperty "view ExitFailure n, where n is non-zero" . property $
+      forAll nonZero >>= (\n -> Identity (ExitFailure n) ^? exitCode === Just (exitfailure0 n))
   , testCase "view ExitFailure 0" $
       runExitcode (Identity (ExitFailure 0) ^. exitCode) @?= (MaybeT (Identity Nothing))
   , testCase "view ExitSuccess" $
@@ -120,4 +125,4 @@ tastyCheckersBatch (name, tests) =
 
 tastyCheckersProperty :: Test -> TestTree
 tastyCheckersProperty =
-  uncurry testProperty
+  uncurry TQC.testProperty


### PR DESCRIPTION
Move property based tests to hedgehog instead of QuickCheck.

There are still QuickCheck dependencies due to our use of checkers (testing laws of typeclass instances).